### PR TITLE
Don't add ActionDispatch::Static middleware

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ title: Changelog
 
 ## main
 
+* Don't add ActionDispatch::Static middleware, if rails does not serve static files
+
+    *Daniel Gonzalez*
+
 * Fix Ruby indentation warning.
 
     *Blake Williams*

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,7 @@ ViewComponent is built by over a hundred members of the community, including:
 <img src="https://avatars.githubusercontent.com/xkraty?s=64" alt="xkraty" width="32" />
 <img src="https://avatars.githubusercontent.com/wdrexler?s=64" alt="wdrexler" width="32" />
 <img src="https://avatars.githubusercontent.com/mattwr18?s=64" alt="mattwr18" width="32" />
+<img src="https://avatars.githubusercontent.com/danigonza?s=64" alt="danigonza" width="32" />
 
 <hr />
 

--- a/lib/view_component/engine.rb
+++ b/lib/view_component/engine.rb
@@ -102,9 +102,13 @@ module ViewComponent
     end
 
     initializer "static assets" do |app|
-      if app.config.view_component.show_previews
+      if serve_static_previews? app.config
         app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/app/assets/vendor")
       end
+    end
+
+    def serve_static_previews?(app_config)
+      app_config.view_component.show_previews && app_config.public_file_server.enabled
     end
 
     config.after_initialize do |app|

--- a/test/view_component/engine_test.rb
+++ b/test/view_component/engine_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ViewComponent::EngineTest < ActionDispatch::IntegrationTest
+  def test_serve_static_previews?
+    app.config.public_file_server.enabled = false
+    refute ViewComponent::Engine.instance.serve_static_previews?(app.config)
+  end
+end


### PR DESCRIPTION
<!-- See https://github.com/github/view_component/blob/main/docs/CONTRIBUTING.md#submitting-a-pull-request -->

### Summary

On the case that we want to have previews on production environment but rails is not managing the static files is not necessary to add the middleware `ActionDispatch::Static`. If not the an error saying `No such middleware to insert before: ActionDispatch::Static` will be raised when we executed `bundle exec rake assets:precompile`.

There is a configuration flag on rails that we can use to check if rails is serving static files: `public_file_server.enabled`. This flag on combination with `view_component.show_previews` is used to know if the middleware should be inserted or not

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file. -->
